### PR TITLE
fix error message in nscang_host_result()

### DIFF
--- a/python/nscang.c
+++ b/python/nscang.c
@@ -70,7 +70,7 @@ nscang_host_result(PyObject *self, PyObject *args, PyObject *kwds)
 		return Py_None;
 	}
 
-	PyErr_Format(PyExc_RuntimeError, "svc_result: %s",
+	PyErr_Format(PyExc_RuntimeError, "host_result: %s",
 	    nscang_client_errstr(client, errstr, sizeof(errstr)));
 	return NULL;
 }


### PR DESCRIPTION
Minor copy/paste bug that I came across while porting the code for a Perl/XS module
